### PR TITLE
Fix incorrect Tailwind class in cancel button

### DIFF
--- a/src/pages/Documentos.tsx
+++ b/src/pages/Documentos.tsx
@@ -86,7 +86,7 @@ const descargar = (doc: (typeof documentos) [number]) => {
                         </button>
                         <button
                           onClick={() => setEditandoId(null)}
-                          className="bg-zinc-600-600 hover:bg-zinc-700 text-sm px-2 py-1 rounded"
+                          className="bg-zinc-600 hover:bg-zinc-700 text-sm px-2 py-1 rounded"
                         >
                           Cancelar
                         </button>


### PR DESCRIPTION
## Summary
- fix Cancelar button style in Documentos page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a04b1d43483269952215014c5e3a5